### PR TITLE
Add factory for new StoreBuilder instances

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -347,3 +347,8 @@ export function getStoreBuilder<R>(name?: string): StoreBuilder<R>
     const builder = namedStoreBuilderMap[name] || (namedStoreBuilderMap[name] = new StoreBuilderImpl<R>())
     return builder
 }
+
+export function newStoreBuilder<R>(): StoreBuilder<R>
+{
+    return new StoreBuilderImpl<R>()
+}


### PR DESCRIPTION
Export a new factory function to create new, unmanaged instances of `StoreBuilderImpl<R>`. Fixes ChristopherKiss/vuex-type-safety#2